### PR TITLE
Support for $BUILD_ARTIFACT_PATHS variable

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/snsnotify/AmazonSNSNotifier.java
+++ b/src/main/java/org/jenkinsci/plugins/snsnotify/AmazonSNSNotifier.java
@@ -9,6 +9,7 @@ import hudson.Launcher;
 import hudson.Util;
 import hudson.model.*;
 import hudson.model.BuildListener;
+import hudson.model.Run.Artifact;
 import hudson.tasks.BuildStepDescriptor;
 import hudson.tasks.BuildStepMonitor;
 import hudson.tasks.Notifier;
@@ -20,6 +21,8 @@ import org.kohsuke.stapler.StaplerRequest;
 
 import java.io.IOException;
 import java.util.Map;
+import java.util.List;
+import java.util.ArrayList;
 import java.util.logging.Logger;
 
 public class AmazonSNSNotifier extends Notifier {
@@ -174,12 +177,23 @@ public class AmazonSNSNotifier extends Notifier {
         try {
             EnvVars envVars = build.getEnvironment(listener);
             envVars.put("BUILD_PHASE", phase.name());
+            envVars.put("BUILD_ARTIFACT_PATHS", artifactPaths(build.getArtifacts()));
             String result = Util.replaceMacro(tmpl, build.getBuildVariableResolver());
             return Util.replaceMacro(result, envVars);
         } catch (Exception e) {
             LOG.warning("Unable to get environment while trying to replace variables on " + tmpl);
             return tmpl;
         }
+    }
+
+    /**
+     * Concatenate build artifact paths into a single new-line separated string.
+     */
+    private String artifactPaths(List<Artifact> artifacts) {
+        List<String> paths = new ArrayList<String>();
+        for (Artifact artifact: artifacts)
+            paths.add(artifact.getDisplayPath());
+        return StringUtils.join(paths, "\n");
     }
 
     /**

--- a/src/main/resources/org/jenkinsci/plugins/snsnotify/AmazonSNSNotifier/help-messageTemplate.html
+++ b/src/main/resources/org/jenkinsci/plugins/snsnotify/AmazonSNSNotifier/help-messageTemplate.html
@@ -1,4 +1,5 @@
 <div>
     Specifies the message (payload) as published to the SNS topic.
     Build variables can be used and are resolved before message is sent.
+    Additional variables include $BUILD_PHASE ("COMPLETED" etc) and $BUILD_ARTIFACT_PATHS (new-line separated list of artifact paths).
 </div>


### PR DESCRIPTION
I expect that this plugin is often used to notify a service which will do something with the build output. Currently such a service can use the $BUILD_URL to query jenkins for the details of the build artifacts but sometimes all that's needed the file names/paths. This patch adds a variable for this case, which can be substituted on the message or subject.
