### PR TITLE
Added Apache HttpCore as a dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,5 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
-    
+
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
@@ -42,6 +42,12 @@
             <artifactId>aws-java-sdk</artifactId>
             <version>RELEASE</version>
         </dependency>
+
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpcore</artifactId>
+            <version>4.4.1</version>
+        </dependency>
     </dependencies>
 
 
@@ -58,6 +64,4 @@
             <url>http://repo.jenkins-ci.org/public/</url>
         </pluginRepository>
     </pluginRepositories>
-</project>  
-  
-
+</project>


### PR DESCRIPTION
Although the plugin builds successfully, it fails to publish anything on a stock Jenkins installation (v1.614) due to a missing HttpCore package. Adding that to the POM and rebuilding fixes the issue.