### PR TITLE
Adding in compatiablity for AWS Instance Role profile

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/snsnotify/AmazonSNSNotifier/global.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/snsnotify/AmazonSNSNotifier/global.jelly
@@ -41,5 +41,14 @@
             <f:booleanRadio name="snsnotify.defaultSendNotificationOnStart" />
         </f:entry>
 
+        <f:entry 
+            title="Use Local Credential" 
+            help="/plugin/snsnotify/help-defaultCredential.html"
+            field="defaultLocalCredential">
+
+            <f:checkbox name="snsnotify.defaultLocalCredential" />
+        </f:entry>
+
+
     </f:section>
 </j:jelly>

--- a/src/main/webapp/help-defaultCredential.html
+++ b/src/main/webapp/help-defaultCredential.html
@@ -1,0 +1,5 @@
+<div>
+  <p>
+  Use the local environment variable AWS_ACCESS_KEY and AWS_SECRET_ACCESS_KEY.
+  </p>
+</div


### PR DESCRIPTION
Providing the option to use AWSCredentialsProviderChain instead of BasicAWSCredentials to support AWS instance profile log in. 