### PR TITLE
Added support for IAM Roles and ability to disable notifications on every build.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ pom.xml.releaseBackup
 *.ipr
 *.iml
 *.iws
+/bin

--- a/src/main/resources/org/jenkinsci/plugins/snsnotify/AmazonSNSNotifier/global.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/snsnotify/AmazonSNSNotifier/global.jelly
@@ -18,6 +18,14 @@
         </f:entry>
 
         <f:entry 
+            title="Use Local Credentials" 
+            help="/plugin/snsnotify/help-defaultCredential.html"
+            field="defaultLocalCredential">
+
+            <f:booleanRadio name="snsnotify.defaultLocalCredential" />
+        </f:entry>
+
+        <f:entry 
             title="Default notification topic ARN" 
             help="/plugin/snsnotify/help-defaultTopicArn.html"
             field="defaultTopicArn">
@@ -41,5 +49,12 @@
             <f:booleanRadio name="snsnotify.defaultSendNotificationOnStart" />
         </f:entry>
 
+        <f:entry 
+            title="Send notifications on every build?"
+            help="/plugin/snsnotify/help-defaultNotifyOnConsecutiveSuccesses.html"
+            field="defaultNotifyOnConsecutiveSuccesses">
+
+            <f:booleanRadio name="snsnotify.defaultNotifyOnConsecutiveSuccesses" />
+        </f:entry>
     </f:section>
 </j:jelly>

--- a/src/main/webapp/help-defaultCredential.html
+++ b/src/main/webapp/help-defaultCredential.html
@@ -1,0 +1,10 @@
+<div>
+    Use the local environment to determine the AWS Credentials in the following order.
+    <ol>
+        <li>Environment Variables - AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY</li>
+        <li>Environment Variables - AWS_ACCESS_KEY and AWS_SECRET_KEY</li>
+        <li>Java System Properties - aws.accessKeyId and aws.secretKey</li>
+        <li>Credential profiles file at the default location (~/.aws/credentials)</li>
+        <li>Instance profile credentials delivered through the Amazon EC2 metadata service</li>
+    </ol>
+</div>

--- a/src/main/webapp/help-defaultNotifyOnConsecutiveSuccesses.html
+++ b/src/main/webapp/help-defaultNotifyOnConsecutiveSuccesses.html
@@ -1,0 +1,4 @@
+<div>
+    The default behavior is to send a notification on every build. If you would only like to receive notifications
+    only on failures and when the build has returned to a successful state, disable this option.
+</div>


### PR DESCRIPTION
I've based the IAM role permissions off the pull request from @jamesHsiaoAcquia with some minor changes including adding a default value of false for the boolean flag.

When builds are being triggered multiple times per hour, being notified of multiple consecutive successes gets very annoying. I've added the option to disable being notified if the result of the current build is SUCCESS and the result of the previous build was SUCCESS. This allows for you to be notified on all failed builds as well as the 1st successful build after a failure.

I've verified that this worked upgrading from a previous version and these features are not enabled by default.