### PR TITLE
Depend on AWS SDK wrapper plugin instead of java lib

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,9 +38,9 @@
 
     <dependencies>
         <dependency>
-            <groupId>com.amazonaws</groupId>
-            <artifactId>aws-java-sdk-sns</artifactId>
-            <version>RELEASE</version>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>aws-java-sdk</artifactId>
+            <version>1.11.403</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
The plugin HPI contained  aws-java-sdk-sns in its library folder.
On a Jenkins instance which also has https://plugins.jenkins.io/aws-java-sdk installed (explicitly or implicitly), this leads to multiple versions of the same library on the classpath. Which again leads to non-deterministic behavior of (groovy-)scripts running in such an environment.

Also see https://jenkins.io/doc/developer/plugin-development/dependencies-and-class-loading/#checking-web-inflib-jar-for-junk for details on that.