### PR TITLE
Fix SNS Api Endpoint for AWS China is not correct

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,10 @@ pom.xml.releaseBackup
 *.iml
 *.iws
 /bin
+
+# ignore ide files
+.classpath
+.factorypath
+.project
+.settings
+.vscode

--- a/src/main/java/org/jenkinsci/plugins/snsnotify/AmazonSNSNotifier.java
+++ b/src/main/java/org/jenkinsci/plugins/snsnotify/AmazonSNSNotifier.java
@@ -256,7 +256,13 @@ public class AmazonSNSNotifier extends Notifier {
         }
 
         String region = arnParts[3];
-        return "sns." + region + ".amazonaws.com";
+        String ret = "";
+        if (region.startsWith("cn-")){
+            ret = "sns." + region + ".amazonaws.com.cn";
+        } else {
+            ret = "sns." + region + ".amazonaws.com";
+        }
+        return ret;
     }
 
 


### PR DESCRIPTION
According to the document: https://docs.amazonaws.cn/en_us/general/latest/gr/rande.html#sns_region
SNS Api Endpoint for AWS China is
sns.{region}.amazonaws.com.cn instead of sns.{region}.amazonaws.com